### PR TITLE
DIM-16: allow reading from multiple Terraform state files

### DIFF
--- a/deployfish/config.py
+++ b/deployfish/config.py
@@ -64,15 +64,20 @@ class Config(object):
         # Setup our boto3_session here because we might need it when retrieving
         # the terraform file from S3
 
-        if use_aws_section:
-            build_boto3_session(self, boto3_session_override=boto3_session)
-        else:
-            build_boto3_session(boto3_session_override=boto3_session)
         self.import_env = import_env
         self.env_file = env_file
         self.tfe_token = tfe_token
         self.environ = None
         self.terraform = None
+
+        if interpolate and 'aws' in self.__raw:
+            self.replace_aws()
+
+        if use_aws_section:
+            build_boto3_session(self, boto3_session_override=boto3_session)
+        else:
+            build_boto3_session(boto3_session_override=boto3_session)
+
         if interpolate:
             if 'terraform' in self.__raw:
                 self.replace_terraform()
@@ -185,6 +190,15 @@ class Config(object):
         #         #     self.environ = os.environ
         #
         #         self.__do_dict(service, replacers)
+
+    def replace_aws(self):
+        if not self.environ:
+            self.environ = {}
+        if self.env_file:
+            self.load_env_file(self.env_file)
+        if self.import_env:
+            self.load_environ()
+        self.__do_dict(self.__raw['aws'], {})
 
     def replace_terraform(self):
         for service in self.__raw['services']:

--- a/deployfish/config.py
+++ b/deployfish/config.py
@@ -196,7 +196,17 @@ class Config(object):
             if 'workspace' in self.__raw['terraform']:
                 self.__raw['terraform']['workspace'] = self.__raw['terraform']['workspace'].format(**replacers)
             else:
-                self.__raw['terraform']['statefile'] = self.__raw['terraform']['statefile'].format(**replacers)
+                if isinstance(self.__raw['terraform'], dict):
+                    try:
+                        self.__raw['terraform']['statefile'] = self.__raw['terraform']['statefile'].format(**replacers)
+                    except KeyError:
+                        print('Skipping replacers')
+                elif isinstance(self.__raw['terraform'], list):
+                    for statefile_dict in self.__raw['terraform']:
+                        try:
+                            statefile_dict['statefile'] = statefile_dict['statefile'].format(**replacers)
+                        except KeyError:
+                            print('Skipping replacers')
 
     def __replace(self, raw, key, value, replacers):
         if isinstance(value, dict):

--- a/deployfish/config.py
+++ b/deployfish/config.py
@@ -201,6 +201,11 @@ class Config(object):
         self.__do_dict(self.__raw['aws'], {})
 
     def replace_terraform(self):
+        if isinstance(self.__raw['terraform'], dict):
+            self.__do_dict(self.__raw['terraform'], {})
+        elif isinstance(self.__raw['terraform'], list):
+            self.__do_list(self.__raw['terraform'], {})
+
         for service in self.__raw['services']:
             replacers = {
                 'environment': service.get('environment', 'prod'),

--- a/deployfish/dplycli.py
+++ b/deployfish/dplycli.py
@@ -38,6 +38,10 @@ def print_service_info(service):
             click.secho('      target_group_arn  : {}'.format(service.load_balancer['target_group_arn']), fg="cyan")
         click.secho('      container_name    : {}'.format(service.load_balancer['container_name']), fg="cyan")
         click.secho('      container_port    : {}'.format(service.load_balancer['container_port']), fg="cyan")
+    if service.dynamic_alb:
+        click.secho('    dynamic_alb:', fg="cyan")
+        for key, val in service.__dynamic_alb:
+            click.secho(f'      {key}  : {val}', fg="cyan")
     if service.scaling:
         click.secho('    application_scaling:', fg="cyan")
         click.secho('      min_capacity      : {}'.format(service.scaling.MinCapacity), fg="cyan")

--- a/deployfish/dplycli.py
+++ b/deployfish/dplycli.py
@@ -40,7 +40,7 @@ def print_service_info(service):
         click.secho('      container_port    : {}'.format(service.load_balancer['container_port']), fg="cyan")
     if service.dynamic_alb:
         click.secho('    dynamic_alb:', fg="cyan")
-        for key, val in service.__dynamic_alb:
+        for key, val in service.dynamic_alb.items():
             click.secho(f'      {key}  : {val}', fg="cyan")
     if service.scaling:
         click.secho('    application_scaling:', fg="cyan")

--- a/deployfish/terraform.py
+++ b/deployfish/terraform.py
@@ -21,12 +21,11 @@ class Terraform(dict):
     def __init__(self, yml=None):
         self.load_yaml(yml)
 
-    def _get_state_file_from_s3(self, config):
-        state_file_url = config['statefile']
-        if 'profile' in config:
+    def _get_state_file_from_s3(self, state_file_url, full_config):
+        if 'profile' in full_config:
             session = boto3.session.Session(
-                profile_name=config['profile'],
-                region_name=config.get('region', None),
+                profile_name=full_config['profile'],
+                region_name=full_config.get('region', None),
             )
         else:
             session = get_boto3_session()
@@ -39,22 +38,41 @@ class Terraform(dict):
             state_file = key.get()["Body"].read().decode('utf-8')
         except ClientError as ex:
             if ex.response['Error']['Code'] == 'NoSuchKey':
-                raise NoSuchStateFile("Could not find Terraform state file {}".format(state_file_url))
+                raise NoSuchStateFile("Could not find Terraform state file {}".format(
+                    state_file_url
+                ))
             else:
                 raise ex
         return json.loads(state_file)
 
-    def get_terraform_state(self, state_file_url):
-        tfstate = self._get_state_file_from_s3(state_file_url)
+    def _process_statefile(self, state_file_url, full_config):
+        tfstate = self._get_state_file_from_s3(state_file_url, full_config)
         major, minor, patch = tfstate['terraform_version'].split('.')
         if int(minor) >= 12:
             for key, value in tfstate['outputs'].items():
+                if key in self:
+                    raise RuntimeError(
+                        'Key {key} already exists / is defined more than once!'.format(key=key)
+                    )
                 self[key] = value
         else:
             for i in tfstate['modules']:
                 if i['path'] == [u'root']:
                     for key, value in i['outputs'].items():
+                        if key in self:
+                            raise RuntimeError(
+                                'Key {key} already exists / is defined more than once!'.format(
+                                    key=key
+                                )
+                            )
                         self[key] = value
+
+    def get_terraform_state(self, config):
+        if isinstance(config, dict):
+            self._process_statefile(config['statefile'], config)
+        elif isinstance(config, list):
+            for statefile in config:
+                self._process_statefile(statefile['statefile'], statefile)
 
     def load_yaml(self, yml):
         self.get_terraform_state(yml)

--- a/deployfish/terraform.py
+++ b/deployfish/terraform.py
@@ -51,8 +51,8 @@ class Terraform(dict):
         if int(minor) >= 12:
             for key, value in tfstate['outputs'].items():
                 if key in self:
-                    raise RuntimeError(
-                        'Key {key} already exists / is defined more than once!'.format(key=key)
+                    print(
+                        'Warning: key {key} already exists / is defined more than once! Overwriting...'.format(key=key)
                     )
                 self[key] = value
         else:
@@ -60,8 +60,8 @@ class Terraform(dict):
                 if i['path'] == [u'root']:
                     for key, value in i['outputs'].items():
                         if key in self:
-                            raise RuntimeError(
-                                'Key {key} already exists / is defined more than once!'.format(
+                            print(
+                                'Warning: key {key} already exists / is defined more than once! Overwriting...'.format(
                                     key=key
                                 )
                             )
@@ -70,13 +70,15 @@ class Terraform(dict):
     def get_terraform_state(self, config):
         if isinstance(config, dict):
             self._process_statefile(config['statefile'], config)
+            self.lookups = config['lookups']
         elif isinstance(config, list):
+            self.lookups = {}
             for statefile in config:
                 self._process_statefile(statefile['statefile'], statefile)
+                self.lookups.update(statefile['lookups'])
 
     def load_yaml(self, yml):
         self.get_terraform_state(yml)
-        self.lookups = yml['lookups']
 
     def lookup(self, attr, keys):
         return self[self.lookups[attr].format(**keys)]['value']


### PR DESCRIPTION
### What does this change do?
It allows Deployfish to read values from multiple Terraform statefiles

### Why is this change needed (what problem does it solve)?
https://tweedinc.atlassian.net/browse/DIM-16

### How has this been tested?
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Includes automated tests for _all_ functionality
- [ ] Includes automated tests for some functionality
- [x] Manual testing performed

I have tested that the values could be read but I couldn't confirm that the deployment actually works. We should:
1. Merge this PR
2. Redeploy an app that uses deployfish without Terraform
3. Deploy Graylog/Fluentd as they only use one statefile (to confirm that previous behaviour is still ok)
4. Deploy Dimebag to make sure multiple statefiles work

### Screenshots (if appropriate):
N/A

### Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Doc change or reformatting (no change to code behavior)
- [ ] Tests only
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Known Issues, Open Questions, Comments
See notes in testing section