### PR TITLE
DIM-37: added other acceptable exit codes for tasks

### DIFF
--- a/deployfish/aws/ecs/Task.py
+++ b/deployfish/aws/ecs/Task.py
@@ -1050,7 +1050,7 @@ class Task(object):
         if 'containers' in yml:
             for c in yml['containers']:
                 if 'valid_exit_codes' in c:
-                    self.exit_codes_overrides[c['name']] = c['valid_exit_codes']
+                    self.exit_codes_overrides[c['name']] = int(c['valid_exit_codes'])
 
         self._get_cluster_arn()
 


### PR DESCRIPTION
Necessary when Fargate kills a task on purpose, so our deployments don't show up as failed.